### PR TITLE
Handle false-y input defaults

### DIFF
--- a/README.md.gotemplate
+++ b/README.md.gotemplate
@@ -43,7 +43,7 @@ There are no inputs defined in this step
 {{- $default = $value }}
 {{- end }}
 {{- end }}
-| `{{ $input_key }}` | {{ markdownTableCompatibleString $description }} | {{ flagList $required $sensitive }} | {{ if $default }}`{{ markdownTableCompatibleString (print $default) }}`{{ end }} |
+| `{{ $input_key }}` | {{ markdownTableCompatibleString $description }} | {{ flagList $required $sensitive }} | {{ if (hasDefault $default) }}`{{ markdownTableCompatibleString (print $default) }}`{{ end }} |
 {{- end }}
 {{- end }}
 </details>

--- a/main.go
+++ b/main.go
@@ -94,11 +94,21 @@ func githubName(repoURL string) string {
 	return strings.Split(repoURL, "github.com/")[1]
 }
 
+// hasDefault tells if an input has a default value or not.
+// Unlike using {{ if $default }}, this handles cases when a bool input is false or when an int input is 0
+func hasDefault(defaultInputValue interface{}) bool {
+	if defaultInputValue == "" {
+		return false
+	}
+	return defaultInputValue != nil
+}
+
 func renderTemplate(step models.StepModel, exampleSection, contribSection string) (string, error) {
 	funcMap := template.FuncMap{
 		"markdownTableCompatibleString": markdownTableCompatibleString,
 		"flagList":                      flagList,
 		"githubName":                    githubName,
+		"hasDefault":                    hasDefault,
 	}
 
 	inventory := templateInventory{


### PR DESCRIPTION
### Checklist

- [ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _MAJOR / MINOR / PATCH_ [version update](https://semver.org/)

### Context

Default input value is missing if the default is `false` or `0`.

### Changes

- Add a template function that checks for true nilness instead of using `{{ if $value }}`

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
