### PR TITLE
Use summary when description is missing

### DIFF
--- a/README.md.gotemplate
+++ b/README.md.gotemplate
@@ -31,7 +31,7 @@ There are no inputs defined in this step
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 {{- range $input := .Step.Inputs }}
-{{- $description := or (index $input "opts" "description") "" }}
+{{- $description := or (index $input "opts" "description") (index $input "opts" "summary") }}
 {{- $required := index $input "opts" "is_required" }}
 {{- $sensitive := index $input "opts" "is_sensitive" }}
 

--- a/README.md.gotemplate
+++ b/README.md.gotemplate
@@ -57,7 +57,7 @@ There are no outputs defined in this step
 | Environment Variable | Description |
 | --- | --- |
 {{- range $output := .Step.Outputs }}
-{{- $description := or (index $output "opts" "description") "" }}
+{{- $description := or (index $output "opts" "description") (index $output "opts" "summary") }}
 {{- $env_var := . }}
 {{- range $key, $value := $output }}
 {{- if ne $key "opts" }}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,7 +12,7 @@ workflows:
         inputs:
         - workflow: e2e
 
-  generate-readme:
+  generate_readme:
     steps:
     - path::./:
         title: Generate my own README

--- a/step.yml
+++ b/step.yml
@@ -22,8 +22,8 @@ inputs:
 - example_section: ""
   opts:
     title: Example section path
-    description: Path to a Markdown file containing step-specific examples. If specified, the contents will be included in the Get started section.
+    summary: Path to a Markdown file containing step-specific examples. If specified, the contents will be included in the Get started section.
 - contrib_section: ""
   opts:
     title: Contributor section path
-    description: Path to a Markdown file about step-specific information for contributors. If specified, the contents will be included in the Contributing section.
+    summary: Path to a Markdown file about step-specific information for contributors. If specified, the contents will be included in the Contributing section.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Context

For inputs and outputs, `description` is an optional field while `summary` is mandatory. `Description` is only used when it needs to be longer than the once sentence summary.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

Use `summary` as a fallback when `description` is not defined

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
