### PR TITLE
Fall back to empty string if neither description nor summary is available

### DIFF
--- a/README.md.gotemplate
+++ b/README.md.gotemplate
@@ -31,7 +31,7 @@ There are no inputs defined in this step
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
 {{- range $input := .Step.Inputs }}
-{{- $description := or (index $input "opts" "description") (index $input "opts" "summary") }}
+{{- $description := or (or (index $input "opts" "description") (index $input "opts" "summary")) "" }}
 {{- $required := index $input "opts" "is_required" }}
 {{- $sensitive := index $input "opts" "is_sensitive" }}
 
@@ -57,7 +57,7 @@ There are no outputs defined in this step
 | Environment Variable | Description |
 | --- | --- |
 {{- range $output := .Step.Outputs }}
-{{- $description := or (index $output "opts" "description") (index $output "opts" "summary") }}
+{{- $description := or (or (index $output "opts" "description") (index $output "opts" "summary")) "" }}
 {{- $env_var := . }}
 {{- range $key, $value := $output }}
 {{- if ne $key "opts" }}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
This step is not versioned.

### Context
* This step currently fails to generate READMEs for steps where inputs don't have a description or a summary.

### Changes
* **Fall back to empty string if neither description nor summary is available for a step input when README is generated.**
